### PR TITLE
feat: improve req body and dc notification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 mlruns
 *.db
+__pycache__/
+.python-version
+.env*


### PR DESCRIPTION
feat: Improve request body untuk trigger retraining.
1. split the `get_uri` into `git_uri` and `folder_location`.
2. no need to use word `get` in request body.

feat: Improve discord notification message. Now request body will be shown in the dc notification. Consider to improve notification when retrain failed, because it is still only tell run_id sekian is failed, no detail at all, but yeah it is just for some cases.