### PR TITLE
fix: update Dockerfile do the copy process at the end

### DIFF
--- a/apps/http-server/Dockerfile
+++ b/apps/http-server/Dockerfile
@@ -1,11 +1,5 @@
 FROM ubuntu:latest
 
-WORKDIR /app
-
-COPY ./main.py .
-
-COPY .env .
-
 RUN apt-get update
 
 RUN apt-get install -y ca-certificates 
@@ -48,5 +42,11 @@ RUN pip install uvicorn
 RUN pip install python-dotenv
 
 RUN pip install docker
+
+WORKDIR /app
+
+COPY ./main.py .
+
+COPY .env .
 
 CMD bash


### PR DESCRIPTION
because it is a quick process not long process, and we want to cache the long process.
if it is at the beginning and we update the py file, the below line dockerfile cache will not being used.
because the top line dockerfile is change